### PR TITLE
Bump minimum Thelia version

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,6 +13,6 @@
         <email>info@thelia.net</email>
     </author>
     <type>delivery</type>
-    <thelia>2.1.0</thelia>
+    <thelia>2.2.0</thelia>
     <stability>alpha</stability>
 </module>


### PR DESCRIPTION
Recent commit 4511008bce3f571078617bfc4cd9bf053f5a50be uses the new `$cellphone` argument of the `OrderAddressEvent` constructor. This argument was introduced in Thelia 2.2.0 (in [this commit](https://github.com/thelia/thelia/commit/6f11129e00492ef7b048329f6be29c8be3f2f898)). This makes this module compatible only with Thelia 2.2.0 or more from now on.
