### PR TITLE
Fix the address in the emails

### DIFF
--- a/Listener/UpdateDeliveryAddress.php
+++ b/Listener/UpdateDeliveryAddress.php
@@ -115,9 +115,8 @@ class UpdateDeliveryAddress extends BaseAction implements EventSubscriberInterfa
     public static function getSubscribedEvents()
     {
         return array(
-            TheliaEvents::ORDER_BEFORE_PAYMENT=>array("update_address", 128),
+            TheliaEvents::ORDER_BEFORE_PAYMENT=>array("update_address", 130),
             TheliaEvents::ORDER_SET_DELIVERY_MODULE=>array("set_address", 128)
         );
     }
-
 }


### PR DESCRIPTION
The priority of the event ORDER_BEFORE_PAYMENT is too low and so the address in the email were not updated.